### PR TITLE
fix when recive multiple packets

### DIFF
--- a/node-nut.js
+++ b/node-nut.js
@@ -10,6 +10,8 @@ class Nut extends EventEmitter {
         this.status = 'idle';
         this.dataInBuff = '';
 
+        this._vars = {};
+
         this._client = new net.Socket();
         this._client.setEncoding('ascii');
 
@@ -88,15 +90,14 @@ class Nut extends EventEmitter {
 
         const dataArray = data.split('\n');
 
-        const vars = {};
         for (const line of dataArray) {
             if (line.indexOf('BEGIN LIST ' + listType) === 0) {
-                // ...
+                this._vars = {};
             } else if (line.indexOf(listType + ' ') === 0) {
                 const matches = re.exec(line);
-                vars[matches[1]] = matches[2];
+                this._vars[matches[1]] = matches[2];
             } else if (line.indexOf('END LIST ' + listType) === 0) {
-                callback(vars, null);
+                callback(this._vars, null);
                 break;
             } else if (line.indexOf('ERR') === 0) {
                 callback(null, line.slice(4));


### PR DESCRIPTION
when the packets are split into several parts, you receive only the last packet.

1 .for example the first packet starts with "BEGIN LIST " and "vars" is filled, the callback is not called because the packet is truncated and does not end with "END LIST"
2. I receive the second packet, "vars" is initialized to {} (so I lose the data of the first packet), it is filled with the last data and when it gets to "END LIST" it executes the callback.
3. the callback returns only the last packet